### PR TITLE
Implement back-end for audio feature

### DIFF
--- a/LogCast.Recruitment.IntegrationTests/LogCast.Recruitment.IntegrationTests.csproj
+++ b/LogCast.Recruitment.IntegrationTests/LogCast.Recruitment.IntegrationTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.16" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Logcast.Recruitment.Web\Logcast.Recruitment.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LogCast.Recruitment.IntegrationTests/LogcastRecruitmentTests.cs
+++ b/LogCast.Recruitment.IntegrationTests/LogcastRecruitmentTests.cs
@@ -1,0 +1,71 @@
+﻿using Logcast.Recruitment.Web;
+using Logcast.Recruitment.Web.Models.Audio;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LogCast.Recruitment.IntegrationTests
+{
+    public class LogcastRecruitmentTests : IClassFixture<LogcastRecruitmentWebApplicationFactory<Program>>
+    {
+        private readonly LogcastRecruitmentWebApplicationFactory<Program> _factory;
+        private readonly HttpClient _client;
+
+        public LogcastRecruitmentTests(LogcastRecruitmentWebApplicationFactory<Program> factory)
+        {
+            _factory = factory;
+            _client = _factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task Valid_upload_audio_file_request_returns_successful_response()
+        {
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes("test file content"));
+            var streamContent = new StreamContent(stream);
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue("audio/mpeg");
+            streamContent.Headers.Add("Content-Disposition", "form-data; name=\"audioFile\"; filename=\"test.mp3\"");
+            var multipartContent = new MultipartFormDataContent();
+            multipartContent.Add(streamContent, "audioFile", "test.mp3");
+
+            var response = await _client.PostAsync("api/audio/audio-file", multipartContent)
+                .ConfigureAwait(false);
+
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var result = await response.Content.ReadFromJsonAsync<UploadAudioFileResponse>()
+                .ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.NotEqual(Guid.Empty, result.AudioId);
+        }
+
+        [Fact]
+        public async Task Upload_audio_file_request_with_invalid_content_type_returns_error()
+        {
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes("test file content"));
+            var streamContent = new StreamContent(stream);
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+            streamContent.Headers.Add("Content-Disposition", "form-data; name=\"audioFile\"; filename=\"test.txt\"");
+            var multipartContent = new MultipartFormDataContent();
+            multipartContent.Add(streamContent, "audioFile", "test.txt");
+
+            var response = await _client.PostAsync("api/audio/audio-file", multipartContent)
+                .ConfigureAwait(false);
+
+            Assert.NotNull(response);
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+
+            var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Contains("Only audio/mpeg content is supported", result);
+        }
+    }
+}

--- a/LogCast.Recruitment.IntegrationTests/LogcastRecruitmentWebApplicationFactory.cs
+++ b/LogCast.Recruitment.IntegrationTests/LogcastRecruitmentWebApplicationFactory.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LogCast.Recruitment.IntegrationTests
+{
+    public class LogcastRecruitmentWebApplicationFactory<TStartup> :
+        WebApplicationFactory<TStartup> where TStartup : class
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                var sp = services.BuildServiceProvider();
+            });
+        }
+    }
+}

--- a/Logcast.Recruitment.DataAccess.Tests/RepositoryTests/AudioRepositoryTests.cs
+++ b/Logcast.Recruitment.DataAccess.Tests/RepositoryTests/AudioRepositoryTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+using Logcast.Recruitment.DataAccess.Entities;
+using Logcast.Recruitment.DataAccess.Exceptions;
+using Logcast.Recruitment.DataAccess.Factories;
+using Logcast.Recruitment.DataAccess.Repositories;
+using Logcast.Recruitment.DataAccess.Services;
+using Logcast.Recruitment.DataAccess.Tests.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Logcast.Recruitment.DataAccess.Tests.RepositoryTests
+{
+    [TestClass]
+    public class AudioRepositoryTests
+    {
+        private readonly Mock<IFileStorage> _fileStorageMock;
+        private readonly IAudioRepository _audioRepository;
+        private readonly ApplicationDbContext _testDbContext;
+
+        public AudioRepositoryTests()
+        {
+            var dbContextFactoryMock = new Mock<IDbContextFactory>();
+
+            _testDbContext = EfConfig.CreateInMemoryTestDbContext();
+            dbContextFactoryMock.Setup(d => d.Create()).Returns(EfConfig.CreateInMemoryApplicationDbContext());
+
+            _fileStorageMock = new Mock<IFileStorage>();
+
+            _audioRepository = new AudioRepository(dbContextFactoryMock.Object, _fileStorageMock.Object);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _testDbContext.Database.EnsureDeleted();
+        }
+
+        [TestMethod]
+        public async Task StoreAudioFileAsync_AudioIdExists_ShouldThrowException()
+        {
+            var audioId = Guid.NewGuid();
+            await _testDbContext.Audio.AddAsync(new Audio(audioId, "name", ".mp3", "audio/mpeg"));
+            await _testDbContext.SaveChangesAsync();
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(()
+                => _audioRepository.StoreAudioFileAsync(Array.Empty<byte>(), audioId, "name", ".mp3", "audio/mpeg"));
+        }
+
+        [TestMethod]
+        public async Task StoreAudioFileAsync_NewAudioId_ShouldCreateNewAudio()
+        {
+            var audioId = Guid.NewGuid();
+
+            await _audioRepository.StoreAudioFileAsync(Array.Empty<byte>(), audioId, "name", ".mp3", "audio/mpeg");
+
+            var audio = await _testDbContext.Audio.SingleAsync();
+
+            Assert.AreEqual(audioId, audio.Id);
+            Assert.AreEqual("name", audio.Name);
+            Assert.AreEqual(".mp3", audio.FileType);
+            Assert.AreEqual($"{audioId}.mp3", audio.FileName);
+            Assert.AreEqual("audio/mpeg", audio.ContentType);
+            Assert.IsNull(audio.Creator);
+            Assert.IsTrue(_fileStorageMock.Invocations.Count == 1);
+        }
+
+        [TestMethod]
+        public async Task StoreAudioMetadataAsync_AudioDoesNotExist_ShouldThrowException()
+        {
+            var audioId = Guid.NewGuid();
+
+            await Assert.ThrowsExceptionAsync<AudioNotFoundException>(()
+                => _audioRepository.StoreAudioMetadataAsync(audioId, "Custom name", "John Smith"));
+        }
+
+        [TestMethod]
+        public async Task StoreAudioMetadataAsync_AudioExists_ShouldUpdateAudioMetadata()
+        {
+            var audioId = Guid.NewGuid();
+            await _testDbContext.Audio.AddAsync(new Audio(audioId, "name", ".mp3", "audio/mpeg"));
+            await _testDbContext.SaveChangesAsync();
+
+            await _audioRepository.StoreAudioMetadataAsync(audioId, "Custom name", "John Smith");
+
+            var audio = await _testDbContext.Audio.SingleAsync();
+
+            Assert.AreEqual(audioId, audio.Id);
+            Assert.AreEqual("Custom name", audio.Name);
+            Assert.AreEqual(".mp3", audio.FileType);
+            Assert.AreEqual($"{audioId}.mp3", audio.FileName);
+            Assert.AreEqual("audio/mpeg", audio.ContentType);
+            Assert.AreEqual("John Smith", audio.Creator);
+        }
+    }
+}

--- a/Logcast.Recruitment.DataAccess/ApplicationDbContext.cs
+++ b/Logcast.Recruitment.DataAccess/ApplicationDbContext.cs
@@ -9,6 +9,8 @@ namespace Logcast.Recruitment.DataAccess
         {
         }
 
+        public DbSet<Audio> Audio { get; set; }
+
         public DbSet<Subscription> Subscriptions { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Logcast.Recruitment.DataAccess/Configuration/ServiceCollectionExtensions.cs
+++ b/Logcast.Recruitment.DataAccess/Configuration/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Logcast.Recruitment.DataAccess.Factories;
 using Logcast.Recruitment.DataAccess.Repositories;
+using Logcast.Recruitment.DataAccess.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,16 +18,23 @@ namespace Logcast.Recruitment.DataAccess.Configuration
         {
             services.AddRepositories();
             services.AddFactories();
+            services.AddServices();
         }
 
         private static void AddRepositories(this IServiceCollection services)
         {
             services.AddTransient<ISubscriptionRepository, SubscriptionRepository>();
+            services.AddTransient<IAudioRepository, AudioRepository>();
         }
 
         private static void AddFactories(this IServiceCollection services)
         {
             services.AddTransient<IDbContextFactory, DbContextFactory>();
+        }
+
+        private static void AddServices(this IServiceCollection services)
+        {
+            services.AddTransient<IFileStorage, FileStorage>();
         }
     }
 }

--- a/Logcast.Recruitment.DataAccess/Entities/Audio.cs
+++ b/Logcast.Recruitment.DataAccess/Entities/Audio.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using Logcast.Recruitment.Shared.Models;
+
+namespace Logcast.Recruitment.DataAccess.Entities
+{
+    public class Audio
+    {
+        public Audio()
+        {
+        }
+
+        public Audio(Guid id, string name, string fileType, string contentType)
+        {
+            Id = id;
+            Name = name;
+            ContentType = contentType;
+            FileType = fileType;
+            CreatedDate = DateTimeOffset.Now;
+        }
+
+        public Guid Id { get; set; }
+
+        [Required] [MaxLength(200)] public string Name { get; set; }
+
+        [Required] [MaxLength(50)] public string ContentType { get; set; }
+
+        [Required] [MaxLength(10)] public string FileType { get; set; }
+
+        [MaxLength(200)] public string Creator { get; set; }
+
+        public DateTimeOffset CreatedDate { get; set; }
+
+        public string FileName => $"{Id}{FileType}";
+
+        public AudioModel ToDomainModel()
+        {
+            return new AudioModel()
+            {
+                ContentType = ContentType,
+                CreatedDate = CreatedDate,
+                Creator = Creator,
+                Id = Id,
+                Name = Name,
+            };
+        }
+    }
+}

--- a/Logcast.Recruitment.DataAccess/Exceptions/AudioNotFoundException.cs
+++ b/Logcast.Recruitment.DataAccess/Exceptions/AudioNotFoundException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Logcast.Recruitment.DataAccess.Exceptions
+{
+    public class AudioNotFoundException : Exception
+    {
+    }
+}

--- a/Logcast.Recruitment.DataAccess/Exceptions/UnsupportedContentTypeException.cs
+++ b/Logcast.Recruitment.DataAccess/Exceptions/UnsupportedContentTypeException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Logcast.Recruitment.DataAccess.Exceptions
+{
+    public class UnsupportedContentTypeException : Exception
+    {
+    }
+}

--- a/Logcast.Recruitment.DataAccess/Exceptions/UnsupportedFileTypeException.cs
+++ b/Logcast.Recruitment.DataAccess/Exceptions/UnsupportedFileTypeException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Logcast.Recruitment.DataAccess.Exceptions
+{
+    public class UnsupportedFileTypeException : Exception
+    {
+    }
+}

--- a/Logcast.Recruitment.DataAccess/Migrations/20220413122945_Audio.Designer.cs
+++ b/Logcast.Recruitment.DataAccess/Migrations/20220413122945_Audio.Designer.cs
@@ -4,14 +4,16 @@ using Logcast.Recruitment.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Logcast.Recruitment.DataAccess.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220413122945_Audio")]
+    partial class Audio
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Logcast.Recruitment.DataAccess/Migrations/20220413122945_Audio.cs
+++ b/Logcast.Recruitment.DataAccess/Migrations/20220413122945_Audio.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Logcast.Recruitment.DataAccess.Migrations
+{
+    public partial class Audio : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Audio",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ContentType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    FileType = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: false),
+                    Creator = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    CreatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Audio", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Audio");
+        }
+    }
+}

--- a/Logcast.Recruitment.DataAccess/Repositories/AudioRepository.cs
+++ b/Logcast.Recruitment.DataAccess/Repositories/AudioRepository.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Logcast.Recruitment.DataAccess.Entities;
+using Logcast.Recruitment.DataAccess.Exceptions;
+using Logcast.Recruitment.DataAccess.Factories;
+using Logcast.Recruitment.DataAccess.Services;
+using Logcast.Recruitment.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Logcast.Recruitment.DataAccess.Repositories
+{
+    public interface IAudioRepository
+    {
+        Task StoreAudioFileAsync(byte[] file, Guid audioId, string name, string fileType, string contentType);
+        Task StoreAudioMetadataAsync(Guid audioId, string name, string creator);
+        Task<AudioModel> GetAudioMetadataAsync(Guid audioId);
+        Task<AudioModel> GetAudioFileAsync(Guid audioId);
+    }
+
+    public class AudioRepository : IAudioRepository
+    {
+        private readonly ApplicationDbContext _applicationDbContext;
+        private readonly IFileStorage _fileStorage;
+
+        public AudioRepository(IDbContextFactory dbContextFactory, IFileStorage fileStorage)
+        {
+            _applicationDbContext = dbContextFactory.Create();
+            _fileStorage = fileStorage;
+        }
+
+        public async Task StoreAudioFileAsync(byte[] file, Guid audioId, string name, string fileType, string contentType)
+        {
+            if (await _applicationDbContext.Audio.AnyAsync(x => x.Id == audioId).ConfigureAwait(false))
+                throw new ArgumentException("AudioId already exists");
+
+            var audio = new Audio(
+                audioId,
+                name,
+                fileType,
+                contentType);
+
+            await _fileStorage.SaveAsync(audio.FileName, file).ConfigureAwait(false);
+
+            try
+            {
+                _applicationDbContext.Audio.Add(audio);
+                await _applicationDbContext.SaveChangesAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                await _fileStorage.DeleteAsync(audio.FileName).ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        public async Task StoreAudioMetadataAsync(Guid audioId, string name, string creator)
+        {
+            var audio = await _applicationDbContext.Audio.SingleOrDefaultAsync(x => x.Id == audioId).ConfigureAwait(false);
+            if (audio is null)
+                throw new AudioNotFoundException();
+
+            if (!string.IsNullOrWhiteSpace(name))
+                audio.Name = name;
+            audio.Creator = creator;
+
+            _applicationDbContext.Audio.Update(audio);
+            await _applicationDbContext.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        public async Task<AudioModel> GetAudioMetadataAsync(Guid audioId)
+        {
+            var audio = await _applicationDbContext.Audio.SingleOrDefaultAsync(x => x.Id == audioId).ConfigureAwait(false);
+            return audio is null
+                ? throw new AudioNotFoundException()
+                : audio.ToDomainModel();
+        }
+
+        public async Task<AudioModel> GetAudioFileAsync(Guid audioId)
+        {
+            var audio = await _applicationDbContext.Audio.SingleOrDefaultAsync(x => x.Id == audioId).ConfigureAwait(false);
+            if (audio is null)
+                throw new AudioNotFoundException();
+
+            var file = await _fileStorage.GetAsync(audio.FileName).ConfigureAwait(false);
+            var audioModel = audio.ToDomainModel();
+            audioModel.File = file;
+            return audioModel;
+        }
+    }
+}

--- a/Logcast.Recruitment.DataAccess/Services/FileStorage.cs
+++ b/Logcast.Recruitment.DataAccess/Services/FileStorage.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Logcast.Recruitment.DataAccess.Services
+{
+    public interface IFileStorage
+    {
+        public Task<byte[]> GetAsync(string fileName);
+        public Task SaveAsync(string fileName, byte[] content);
+        public Task DeleteAsync(string fileName);
+    }
+
+    public class FileStorage : IFileStorage
+    {
+        private readonly string _contentFolder;
+
+        public FileStorage()
+        {
+            _contentFolder = AppContext.BaseDirectory;
+        }
+
+        public async Task<byte[]> GetAsync(string fileName)
+        {
+            string path = Path.Combine(_contentFolder, fileName);
+            return await File.ReadAllBytesAsync(path).ConfigureAwait(false);
+        }
+
+        public async Task SaveAsync(string fileName, byte[] content)
+        {
+            string path = Path.Combine(_contentFolder, fileName);
+            await File.WriteAllBytesAsync(path, content).ConfigureAwait(false);
+        }
+
+        public Task DeleteAsync(string fileName)
+        {
+            string path = Path.Combine(_contentFolder, fileName);
+            File.Delete(path);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Logcast.Recruitment.Domain.Tests/ServiceTests/AudioServiceTests.cs
+++ b/Logcast.Recruitment.Domain.Tests/ServiceTests/AudioServiceTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using Logcast.Recruitment.DataAccess.Exceptions;
+using Logcast.Recruitment.DataAccess.Repositories;
+using Logcast.Recruitment.Domain.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Logcast.Recruitment.Domain.Tests.ServiceTests
+{
+    [TestClass]
+    public class AudioServiceTests
+    {
+        private readonly Mock<IAudioRepository> _audioRepositoryMock;
+        private readonly Mock<IIdGenerator> _idGeneratorMock;
+        private readonly IAudioService _audioService;
+        private readonly Guid _guid = Guid.NewGuid();
+
+        public AudioServiceTests()
+        {
+            _audioRepositoryMock = new Mock<IAudioRepository>();
+            _idGeneratorMock = new Mock<IIdGenerator>();
+            _idGeneratorMock.Setup(e => e.NewId()).Returns(_guid);
+            _audioService = new AudioService(_audioRepositoryMock.Object, _idGeneratorMock.Object);
+        }
+
+        [TestMethod]
+        public async Task StoreAudioFileAsync_NoErrors_VerifyCalls()
+        {
+            var file = Array.Empty<byte>();
+            var name = "name";
+            var fileType = ".mp3";
+            var contentType = "audio/mpeg";
+            await _audioService.StoreAudioFileAsync(file, $"{name}{fileType}", contentType);
+
+            _audioRepositoryMock.Verify(a => a.StoreAudioFileAsync(file, _guid, name, fileType, contentType));
+        }
+
+        [TestMethod]
+        public async Task StoreAudioFileAsync_InvalidContentType_ShouldThrowException()
+        {
+            var file = Array.Empty<byte>();
+            var name = "name";
+            var fileType = ".mp3";
+            var contentType = "audio";
+
+            await Assert.ThrowsExceptionAsync<UnsupportedContentTypeException>(() => _audioService.StoreAudioFileAsync(file, $"{name}{fileType}", contentType));
+
+            Assert.AreEqual(0, _audioRepositoryMock.Invocations.Count);
+        }
+    }
+}

--- a/Logcast.Recruitment.Domain/Configuration/ServiceCollectionExtension.cs
+++ b/Logcast.Recruitment.Domain/Configuration/ServiceCollectionExtension.cs
@@ -13,6 +13,8 @@ namespace Logcast.Recruitment.Domain.Configuration
         private static void AddServices(this IServiceCollection services)
         {
             services.AddTransient<ISubscriptionService, SubscriptionService>();
+            services.AddTransient<IAudioService, AudioService>();
+            services.AddTransient<IIdGenerator, IdGenerator>();
         }
     }
 }

--- a/Logcast.Recruitment.Domain/Services/AudioService.cs
+++ b/Logcast.Recruitment.Domain/Services/AudioService.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Logcast.Recruitment.DataAccess.Exceptions;
+using Logcast.Recruitment.DataAccess.Repositories;
+using Logcast.Recruitment.Shared.Models;
+
+namespace Logcast.Recruitment.Domain.Services
+{
+    public interface IAudioService
+    {
+        Task<Guid> StoreAudioFileAsync(byte[] file, string fileName, string contentType);
+        Task StoreAudioMetadataAsync(Guid audioId, string name, string creator);
+        Task<AudioModel> GetAudioMetadataAsync(Guid audioId);
+        Task<AudioModel> GetAudioFileAsync(Guid audioId);
+    }
+
+    public class AudioService : IAudioService
+    {
+        private readonly IAudioRepository _audioRepository;
+        private readonly IIdGenerator _idGenerator;
+
+        public AudioService(IAudioRepository audioRepository, IIdGenerator idGenerator)
+        {
+            _audioRepository = audioRepository;
+            _idGenerator = idGenerator;
+        }
+
+        public async Task<Guid> StoreAudioFileAsync(byte[] file, string fileName, string contentType)
+        {
+            if (file is null)
+                throw new ArgumentNullException(nameof(file));
+            if (string.IsNullOrEmpty(fileName))
+                throw new ArgumentException($"'{nameof(fileName)}' cannot be null or empty.", nameof(fileName));
+            if (string.IsNullOrEmpty(contentType))
+                throw new ArgumentException($"'{nameof(contentType)}' cannot be null or empty.", nameof(contentType));
+
+            if (contentType != "audio/mpeg")
+                throw new UnsupportedContentTypeException();
+            if (Path.GetExtension(fileName) != ".mp3")
+                throw new UnsupportedFileTypeException();
+
+            var audioId = _idGenerator.NewId();
+            await _audioRepository
+                .StoreAudioFileAsync(file, audioId, Path.GetFileNameWithoutExtension(fileName), Path.GetExtension(fileName), contentType)
+                .ConfigureAwait(false);
+            return audioId;
+        }
+
+        public async Task StoreAudioMetadataAsync(Guid audioId, string name, string creator)
+        {
+            if (string.IsNullOrEmpty(creator))
+                throw new ArgumentException($"'{nameof(creator)}' cannot be null or empty.", nameof(creator));
+
+            await _audioRepository.StoreAudioMetadataAsync(audioId, name, creator).ConfigureAwait(false);
+        }
+
+        public async Task<AudioModel> GetAudioMetadataAsync(Guid audioId)
+        {
+            return await _audioRepository.GetAudioMetadataAsync(audioId).ConfigureAwait(false);
+        }
+
+        public async Task<AudioModel> GetAudioFileAsync(Guid audioId)
+        {
+            return await _audioRepository.GetAudioFileAsync(audioId).ConfigureAwait(false);
+        }
+    }
+}

--- a/Logcast.Recruitment.Domain/Services/GuidGenerator.cs
+++ b/Logcast.Recruitment.Domain/Services/GuidGenerator.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Logcast.Recruitment.Domain.Services
+{
+    public interface IIdGenerator
+    {
+        Guid NewId();
+    }
+
+    public class IdGenerator : IIdGenerator
+    {
+        public Guid NewId()
+        {
+            return Guid.NewGuid();
+        }
+    }
+}

--- a/Logcast.Recruitment.Shared/Models/AudioModel.cs
+++ b/Logcast.Recruitment.Shared/Models/AudioModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Logcast.Recruitment.Shared.Models
+{
+    public class AudioModel
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string ContentType { get; set; }
+
+        public string Creator { get; set; }
+
+        public DateTimeOffset CreatedDate { get; set; }
+
+        public byte[] File { get; set; }
+    }
+}

--- a/Logcast.Recruitment.Web/Controllers/AudioController.cs
+++ b/Logcast.Recruitment.Web/Controllers/AudioController.cs
@@ -2,6 +2,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Threading.Tasks;
+using Logcast.Recruitment.DataAccess.Exceptions;
+using Logcast.Recruitment.Domain.Services;
 using Logcast.Recruitment.Web.Models.Audio;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,8 +15,11 @@ namespace Logcast.Recruitment.Web.Controllers
     [Route("api/audio")]
     public class AudioController : ControllerBase
     {
-        public AudioController()
+        private readonly IAudioService _audioService;
+
+        public AudioController(IAudioService audioService)
         {
+            _audioService = audioService;
         }
 
         [HttpPost("audio-file")]
@@ -22,34 +27,91 @@ namespace Logcast.Recruitment.Web.Controllers
         [ProducesResponseType(typeof(UploadAudioFileResponse), StatusCodes.Status200OK)]
         public async Task<IActionResult> UploadAudioFile(IFormFile audioFile)
         {
-	        //TODO: Store Audio File
-	        return Ok();
+            if (audioFile is null || audioFile.Length == 0 || string.IsNullOrWhiteSpace(audioFile.Name))
+                return BadRequest(new { message = "Invalid file" });
+
+            try
+            {
+                using var stream = new MemoryStream(audioFile.Length > int.MaxValue ? int.MaxValue : (int)audioFile.Length);
+                await audioFile.CopyToAsync(stream);
+                var audioId = await _audioService.StoreAudioFileAsync(stream.ToArray(), audioFile.FileName, audioFile.ContentType);
+                return Ok(new UploadAudioFileResponse(audioId));
+            }
+            catch (Exception e)
+            {
+                if (e is UnsupportedContentTypeException)
+                    return BadRequest(new { message = "Only audio/mpeg content is supported" });
+                if (e is UnsupportedFileTypeException)
+                    return BadRequest(new { message = "Only mp3 files are supported" });
+
+                Console.WriteLine(e);
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
         }
 
         [HttpPost]
         [SwaggerResponse(StatusCodes.Status200OK, "Audio metadata registered successfully")]
-        public async Task<IActionResult> AddAudioMetadata([Required] [FromBody] AddAudioRequest request)
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Audio entry not found")]
+        public async Task<IActionResult> AddAudioMetadata([Required][FromBody] AddAudioRequest request)
         {
-            //TODO: Store Audio Metadata
-            return Ok();
+            if (request == null || request.AudioId == Guid.Empty)
+                return BadRequest(new { message = $"{nameof(request.AudioId)} is required" });
+
+            try
+            {
+                await _audioService.StoreAudioMetadataAsync(request.AudioId, request.Name, request.Creator);
+                return Ok();
+            }
+            catch (Exception e)
+            {
+                if (e is AudioNotFoundException)
+                    return NotFound($"Audio with provided Id not found");
+
+                Console.WriteLine(e);
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
         }
 
         [HttpGet("{audioId:Guid}")]
         [SwaggerResponse(StatusCodes.Status200OK, "Audio metadata fetched successfully", typeof(AudioMetadataResponse))]
         [ProducesResponseType(typeof(AudioMetadataResponse), StatusCodes.Status200OK)]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Audio entry not found")]
         public async Task<IActionResult> GetAudioMetadata([FromRoute] Guid audioId)
         {
-	        //TODO: Get Audio Metadata
-	        return Ok();
+            try
+            {
+                var audio = await _audioService.GetAudioMetadataAsync(audioId);
+                return Ok(new AudioMetadataResponse(audio));
+            }
+            catch (Exception e)
+            {
+                if (e is AudioNotFoundException)
+                    return NotFound($"Audio with provided Id not found");
+
+                Console.WriteLine(e);
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
         }
 
         [HttpGet("stream/{audioId:Guid}")]
         [SwaggerResponse(StatusCodes.Status200OK, "Preview stream started successfully", typeof(FileContentResult))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Audio entry not found")]
         [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetAudioStream([FromRoute] Guid audioId)
         {
-	        //TODO: Get stored audio file and return stream
-            return File(new MemoryStream(), "audio/mpeg");
+            try
+            {
+                var audio = await _audioService.GetAudioFileAsync(audioId);
+                return File(new MemoryStream(audio.File, false), audio.ContentType);
+            }
+            catch (Exception e)
+            {
+                if (e is AudioNotFoundException)
+                    return NotFound($"Audio with provided Id not found");
+
+                Console.WriteLine(e);
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
         }
-	}
+    }
 }

--- a/Logcast.Recruitment.Web/Models/Audio/AddAudioRequest.cs
+++ b/Logcast.Recruitment.Web/Models/Audio/AddAudioRequest.cs
@@ -1,6 +1,14 @@
-﻿namespace Logcast.Recruitment.Web.Models.Audio
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Logcast.Recruitment.Web.Models.Audio
 {
 	public class AddAudioRequest
 	{
+		public Guid AudioId { get; set; }
+
+		[MaxLength(200)] public string Name { get; set; }
+
+		[Required] [MaxLength(200)] public string Creator { get; set; }
 	}
 }

--- a/Logcast.Recruitment.Web/Models/Audio/AudioMetadataResponse.cs
+++ b/Logcast.Recruitment.Web/Models/Audio/AudioMetadataResponse.cs
@@ -1,6 +1,18 @@
-﻿namespace Logcast.Recruitment.Web.Models.Audio
+﻿using System;
+
+namespace Logcast.Recruitment.Web.Models.Audio
 {
-	public class AudioMetadataResponse
-	{
-	}
+    public class AudioMetadataResponse
+    {
+        public AudioMetadataResponse(Shared.Models.AudioModel audioModel)
+        {
+            Creator = audioModel.Creator;
+            Name = audioModel.Name;
+            AudioId = audioModel.Id;
+        }
+
+        public string Creator { get; set; }
+        public string Name { get; set; }
+        public Guid AudioId { get; set; }
+    }
 }

--- a/Logcast.Recruitment.Web/Models/Audio/UploadAudioFileResponse.cs
+++ b/Logcast.Recruitment.Web/Models/Audio/UploadAudioFileResponse.cs
@@ -1,6 +1,14 @@
-﻿namespace Logcast.Recruitment.Web.Models.Audio
+﻿using System;
+
+namespace Logcast.Recruitment.Web.Models.Audio
 {
 	public class UploadAudioFileResponse
 	{
-	}
+        public UploadAudioFileResponse(Guid audioId)
+        {
+            AudioId = audioId;
+        }
+
+        public Guid AudioId { get; set; }
+    }
 }

--- a/Logcast.Recruitment.sln
+++ b/Logcast.Recruitment.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29905.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "hosts", "hosts", "{483226D2-2A9E-4A0D-9A4D-43B64A9C2004}"
 EndProject
@@ -22,6 +22,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Logcast.Recruitment.Domain.Tests", "Logcast.Recruitment.Domain.Tests\Logcast.Recruitment.Domain.Tests.csproj", "{AEB2909A-016E-4A25-A6E0-173E9632E16B}"
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{C81DC948-4BE8-4F58-B3AC-31A10EF22187}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogCast.Recruitment.IntegrationTests", "LogCast.Recruitment.IntegrationTests\LogCast.Recruitment.IntegrationTests.csproj", "{FCEEACE4-AB80-4C13-89CD-5EC96F39DAC9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,10 @@ Global
 		{C81DC948-4BE8-4F58-B3AC-31A10EF22187}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C81DC948-4BE8-4F58-B3AC-31A10EF22187}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C81DC948-4BE8-4F58-B3AC-31A10EF22187}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCEEACE4-AB80-4C13-89CD-5EC96F39DAC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCEEACE4-AB80-4C13-89CD-5EC96F39DAC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCEEACE4-AB80-4C13-89CD-5EC96F39DAC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCEEACE4-AB80-4C13-89CD-5EC96F39DAC9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -68,6 +74,7 @@ Global
 		{6D8170A7-0010-4CA7-820E-A1E036AE195C} = {483226D2-2A9E-4A0D-9A4D-43B64A9C2004}
 		{2AFA5AF9-91B1-401B-A121-D1A14C18A8E1} = {7E9B1BD9-F185-4E03-AA58-AA56A210ED05}
 		{AEB2909A-016E-4A25-A6E0-173E9632E16B} = {7E9B1BD9-F185-4E03-AA58-AA56A210ED05}
+		{FCEEACE4-AB80-4C13-89CD-5EC96F39DAC9} = {7E9B1BD9-F185-4E03-AA58-AA56A210ED05}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {918EB507-94B1-454E-9DF8-6BFA83E31DDB}


### PR DESCRIPTION
- UploadAudioFile
- AddAudioMetadata
- GetAudioMetadata
- GetAudioStream

Some notes:

- Implementation tries to follow existing code style, architecture, contracts
- Assume that UploadAudioFile has to be called first, to create the audio entry,
  and then AddAudioMetadata can be called to "update" metadata on the existing audio entry
- Audio files are stored on file system (audioId (guid) used as file name),
  reference and metadata is stored in DB
- Metadata only contains a few fields, to keep it simple
- Upload is restricted to mp3 files, though extensible to other types
- Implemented few unit tests, and few integration tests
- xUnit used for Integration tests